### PR TITLE
Fix problem with sending metasteps with name longer than 1024 chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,9 +126,9 @@ module.exports = (config) => {
   });
 
   event.dispatcher.on(event.step.before, (step) => {
-    recorder.add(async () => {      
+    recorder.add(async () => {
       const parent = await startMetaSteps(step);
-      stepObj = startTestItem(step.toString().slice(0, 300), rp_STEP, parent.tempId);
+      stepObj = startTestItem(step.toString().slice(0, 1024), rp_STEP, parent.tempId);
       step.tempId = stepObj.tempId;
     })
   });
@@ -335,7 +335,7 @@ module.exports = (config) => {
       metaStepObj = currentMetaSteps[i-1] || metaStepObj;
 
       const isNested = !!metaStepObj.tempId;
-      metaStepObj = startTestItem(metaStep.toString(), rp_STEP , metaStepObj.tempId || testObj.tempId, false);
+      metaStepObj = startTestItem(metaStep.toString().slice(0, 1024), rp_STEP , metaStepObj.tempId || testObj.tempId, false);
       metaStep.tempId = metaStepObj.tempId;
       debug(`${metaStep.tempId}: The stepId '${metaStep.toString()}' is started. Nested: ${isNested}`);
     }


### PR DESCRIPTION
Fix problem with metasteps name longer than 1024 characters and resize step name from 300 to 1024 characters.